### PR TITLE
Added support for date formats with dashes

### DIFF
--- a/lib/american_date.rb
+++ b/lib/american_date.rb
@@ -1,10 +1,10 @@
 require 'date'
 
 if RUBY_VERSION >= '1.9'
-  # Modify parsing methods to handle american date format correctly.
+  # Modify parsing methods to handle american date format correctly. 
   class << Date
-    # American date format detected by the library.
-    AMERICAN_DATE_RE = %r_\A\s*(\d{1,2})/(\d{1,2})/(\d{4}|\d{2})_.freeze
+    # American date format detected by the library.  Note that either forward slashes (/) or dashes (-) can be used for the date separator.
+    AMERICAN_DATE_RE = %r_\A\s*(\d{1,2})(?:\/|-)(\d{1,2})(?:\/|-)(\d{4}|\d{2})_.freeze
 
     # Alias for stdlib Date._parse
     alias _parse_without_american_date _parse

--- a/spec/american_date_spec.rb
+++ b/spec/american_date_spec.rb
@@ -23,8 +23,34 @@ describe "Date.parse" do
     Date.parse('1/2').should == Date.new(Time.now.year, 1, 2)
   end
 
+  specify "should use american date format for dd-mm-yy" do
+    Date.parse('01-02-03', true).should == Date.new(2003, 1, 2)
+  end
+
+  specify "should use american date format for d-m-yy" do
+    Date.parse('1-2-03', true).should == Date.new(2003, 1, 2)
+    Date.parse('1-2-03', false).should == Date.new(3, 1, 2)
+  end
+
+  specify "should use american date format for dd-mm-yyyy" do
+    Date.parse('01-02-2003').should == Date.new(2003, 1, 2)
+  end
+
+  # Note - I tried creating the following specs for dates with dashes but no year, but they do no work.
+  #
+  # * should use american date format for dd-mm
+  # * "should use american date format for d-m
+  #
+  # What happens is the short format of these dates (i.e. 1/2 or 1-2) does not match the AMERICAN_DATE_RE reqular expression. 
+  # The convert_american_to_iso method just returns the input string unchanged because of this, and it just so happens that 
+  # the base Date.parse method works on two digit dates with the format "1/2" but not with the format "1-2", so the tests
+  # for the d/m year-less formats work.
+  #
+  # The same goes for the DateTime.parse, Time.parse and Date._parse tests for those year-less formats.
+
   specify "should ignore preceding whitespace" do
     Date.parse('  01/02/2003').should == Date.new(2003, 1, 2)
+    Date.parse('  01-02-2003').should == Date.new(2003, 1, 2)
   end
 end
 
@@ -50,8 +76,22 @@ describe "DateTime.parse" do
     DateTime.parse('1/2').should == DateTime.new(Time.now.year, 1, 2)
   end
 
+  specify "should use american date format for dd-mm-yy" do
+    DateTime.parse('01-02-03', true).should == DateTime.new(2003, 1, 2)
+  end
+
+  specify "should use american date format for d-m-yy" do
+    DateTime.parse('1-2-03', true).should == DateTime.new(2003, 1, 2)
+    DateTime.parse('1-2-03', false).should == DateTime.new(3, 1, 2)
+  end
+
+  specify "should use american date format for dd-mm-yyyy" do
+    DateTime.parse('01-02-2003').should == DateTime.new(2003, 1, 2)
+  end
+
   specify "should ignore preceding whitespace" do
     DateTime.parse('  01/02/2003').should == DateTime.new(2003, 1, 2)
+    DateTime.parse('  01-02-2003').should == DateTime.new(2003, 1, 2)
   end
 
   specify "should work with times" do
@@ -80,12 +120,25 @@ describe "Time.parse" do
     Time.parse('1/2').should == Time.local(Time.now.year, 1, 2)
   end
 
+  specify "should use american date format for dd-mm-yy" do
+    Time.parse('01-02-03', true).should == Time.local(2003, 1, 2)
+  end
+
+  specify "should use american date format for d-m-yy" do
+    Time.parse('1-2-03', true).should == Time.local(2003, 1, 2)
+  end
+
+  specify "should use american date format for dd-mm-yyyy" do
+    Time.parse('01-02-2003').should == Time.local(2003, 1, 2)
+  end
+
   specify "should ignore preceding whitespace" do
     Time.parse('  01/02/2003').should == Time.local(2003, 1, 2)
   end
 
   specify "should work with times" do
     Time.parse('01/02/2003 10:20:30').should == Time.local(2003, 1, 2, 10, 20, 30)
+    Time.parse('01-02-2003 10:20:30').should == Time.local(2003, 1, 2, 10, 20, 30)
   end
 end
 
@@ -110,12 +163,27 @@ describe "Date._parse" do
   specify "should use american date format for d/m" do
     Date._parse('1/2').should == {:mon=>1, :mday=>2}
   end
+  
+  specify "should use american date format for dd-mm-yy" do
+    Date._parse('01-02-03', true).should == {:year=>2003, :mon=>1, :mday=>2}
+  end
+
+  specify "should use american date format for d-m-yy" do
+    Date._parse('1-2-03', true).should == {:year=>2003, :mon=>1, :mday=>2}
+    Date._parse('1-2-03', false).should == {:year=>3, :mon=>1, :mday=>2}
+  end
+
+  specify "should use american date format for dd-mm-yyyy" do
+    Date._parse('01-02-2003').should == {:year=>2003, :mon=>1, :mday=>2}
+  end
 
   specify "should ignore preceding whitespace" do
     Date._parse('  01/02/2003').should == {:year=>2003, :mon=>1, :mday=>2}
+    Date._parse('  01-02-2003').should == {:year=>2003, :mon=>1, :mday=>2}
   end
 
   specify "should work with times" do
     DateTime._parse('01/02/2003 10:20:30').should == {:year=>2003, :mon=>1, :mday=>2, :hour=>10, :min=>20, :sec=>30}
+    DateTime._parse('01-02-2003 10:20:30').should == {:year=>2003, :mon=>1, :mday=>2, :hour=>10, :min=>20, :sec=>30}
   end
 end


### PR DESCRIPTION
Hi Jeremy,

My fork contain a change to allow dates with dashes to work with this gem.  For example, Date.parse("01-02-2012") and Date.parse("01-02-12")

I also added specs to test my changes.  Please see the note that I left in spec/american_date_spec.rb pertaining to year-less date formats that use dashes.  Those formats are not supported by my change.  My note explains why.

I would really appreciate it if you would consider merging my work into your gem.  We have a rather large Rails 2.x app that we're currently migrating to Rails 3.x, and this app accepts date and datetime input all over the place from users with the "dd-mm-YYYY" format.  At this point I don't want to fix the app to only accept the mm/dd/YYYY format, and I also don't want to maintain my own fork of this gem.

Also - if you decide to accept my changes, you'll see from my commit that I didn't update the README.doc or american_date.gemspec file.

Best Regards,
Denis Ahearn
