### PR TITLE
Prevents exception if nil string is passed in...

### DIFF
--- a/lib/american_date.rb
+++ b/lib/american_date.rb
@@ -20,7 +20,7 @@ if RUBY_VERSION >= '1.9'
 
       # Transform american dates into ISO dates before parsing.
       def parse(string, comp=true)
-        parse_without_american_date(convert_american_to_iso(string), comp)
+        parse_without_american_date(convert_american_to_iso(string), comp) unless string.nil?
       end
     end
 
@@ -28,7 +28,7 @@ if RUBY_VERSION >= '1.9'
 
     # Transform american date fromat into ISO format.
     def convert_american_to_iso(string)
-      string.sub(AMERICAN_DATE_RE){|m| "#$3-#$1-#$2"}
+      string.sub(AMERICAN_DATE_RE){|m| "#$3-#$1-#$2"} unless string.nil?
     end
   end
 


### PR DESCRIPTION
I was having `NoMethodError` relating to `sub` not being found in Nil:NilClass so I decided to patch this for my purposes.

I'm not sure if this is the best way to handle this since I'm fairly new to Ruby.

I'm open to suggestions...

Thanks for the great utility!
