### PR TITLE
Fix for Rubinius 2.0

### DIFF
--- a/lib/american_date.rb
+++ b/lib/american_date.rb
@@ -12,9 +12,16 @@ if RUBY_VERSION >= '1.9'
     # Alias for stdlib Date._parse
     alias _parse_without_american_date _parse
 
-    # Transform american dates into ISO dates before parsing.
-    def _parse(string, comp=true)
-      _parse_without_american_date(convert_american_to_iso(string), comp)
+    if RUBY_ENGINE == 'rbx'
+      # Transform american dates into ISO dates before parsing.
+      def _parse(string, comp=true, return_bag=false)
+        _parse_without_american_date(convert_american_to_iso(string), comp, return_bag)
+      end
+    else
+      # Transform american dates into ISO dates before parsing.
+      def _parse(string, comp=true)
+        _parse_without_american_date(convert_american_to_iso(string), comp)
+      end
     end
 
     if RUBY_VERSION >= '1.9.3'


### PR DESCRIPTION
I ran into a problem where this gem wasn't working when I wanted to switch to Rubinius, so I tracked this down and fixed it.

Since this relies on monkeypatching a function (`_parse`), that a user wouldn't normally call, and internally Rubinius uses a different arity on `_parse`, I think this patch is probably a good idea.  : )  What do you think?
