### PR TITLE
add Travis, test with ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+bundler_args: ''
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-2.1
+  - rbx-2.2
+matrix:
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: jruby-18mode
+    - rvm: rbx-2.1
+    - rvm: 1.9.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gemspec
+
+group :test do
+  gem 'rspec', '~> 2.14'
+  gem 'rake', '~> 10.2'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,26 @@
+PATH
+  remote: .
+  specs:
+    american_date (1.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    rake (10.2.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  american_date!
+  rake (~> 10.2)
+  rspec (~> 2.14)

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,8 @@
 = ruby-american_date
 
+{<img src="https://travis-ci.org/jeremyevans/ruby-american_date.png" />[https://travis-ci.org/jeremyevans/ruby-american_date]
+{<img src="https://codeclimate.com/github/jeremyevans/ruby-american_date.png" />}[https://codeclimate.com/github/jeremyevans/ruby-american_date]
+
 ruby-american_date exists to make ruby 1.9+ parse american-style
 month/day/year dates correctly, with behavior matching ruby 1.8.7.
 It can also be used on earlier ruby version, but it is basically
@@ -26,12 +29,12 @@ and the C extension date parser (>=1.9.3).
 
 == Tested ruby versions
 
-* ruby 1.8.6, 1.8.7, 1.9.2, 1.9.3, 2.0.0
-* rubinius 1.2.4
-* jruby 1.6.5 (both --1.8 and --1.9 modes)
+* ruby 1.8.6, 1.8.7, 1.9.2, 1.9.3, 2.0.0, 2.1.0
+* rubinius 1.2.4, 2.2.6
+* jruby 1.6.5, 1.7.9 (both --1.8 and --1.9 modes)
 
 == Installation
-   
+
 ruby-american_date is distributed as a gem, and can be installed with:
 
   gem install american_date


### PR DESCRIPTION
@jeremyevans Thanks for this gem!  It would be helpful to see build status for newer rubies, so this PR adds Travis testing.
- Gemfile (so travis can build these)
- Add travis-ci build badge and code climate.
- Update tested ruby versions.

Note, I tested travis builds with my fork here: https://travis-ci.org/spovich/ruby-american_date
You will need to login to travis and create your profile to get the build badge link in this PR to work.
