### PR TITLE
Properly ignore dates that do not match the American Format

### DIFF
--- a/lib/american_date.rb
+++ b/lib/american_date.rb
@@ -29,6 +29,10 @@ if RUBY_VERSION >= '1.9'
 
     private
 
+    def valid_month?(month_string)
+      month_string.to_i <= 12
+    end
+
     # Transform american date fromat into ISO format.
     def convert_american_to_iso(string)
       unless string.is_a?(String)
@@ -42,7 +46,7 @@ if RUBY_VERSION >= '1.9'
           raise TypeError, "no implicit conversion of #{string.inspect} into String"
         end
       end
-      string.sub(AMERICAN_DATE_RE){|m| "#$3-#$1-#$2"}
+      string.sub(AMERICAN_DATE_RE){|m| valid_month?($1) ? "#$3-#$1-#$2" : "#$1/#$2/#$3"}
     end
   end
 

--- a/spec/american_date_spec.rb
+++ b/spec/american_date_spec.rb
@@ -208,6 +208,10 @@ describe "Time.parse" do
 end
 
 describe "Date._parse" do
+  specify "should correctly parse dd/mm/yy" do
+    Date._parse('18/02/2003', true).should == {:year=>2003, :mon=>2, :mday=>18}
+  end
+
   specify "should use american date format for dd/mm/yy" do
     Date._parse('01/02/03', true).should == {:year=>2003, :mon=>1, :mday=>2}
   end


### PR DESCRIPTION
In some cases, the regex picks up dates that are not in the
American format and when changed they become invalid before
being passed to the original Date or DateTime parse method.

fixes #10
