### PR TITLE
Date.parse has three arguments, not two.

### DIFF
--- a/lib/american_date.rb
+++ b/lib/american_date.rb
@@ -22,8 +22,8 @@ if RUBY_VERSION >= '1.9'
       alias parse_without_american_date parse
 
       # Transform american dates into ISO dates before parsing.
-      def parse(string, comp=true)
-        parse_without_american_date(convert_american_to_iso(string), comp)
+      def parse(string, comp=true, start=Date::ITALY)
+        parse_without_american_date(convert_american_to_iso(string), comp, start)
       end
     end
 
@@ -53,8 +53,8 @@ if RUBY_VERSION >= '1.9'
       alias parse_without_american_date parse
 
       # Transform american dates into ISO dates before parsing.
-      def parse(string, comp=true)
-        parse_without_american_date(convert_american_to_iso(string), comp)
+      def parse(string, comp=true, start=DateTime::ITALY)
+        parse_without_american_date(convert_american_to_iso(string), comp, start)
       end
     end
   end


### PR DESCRIPTION
We have to keep compatibility with the original parse method

http://ruby-doc.org/stdlib-1.8.7/libdoc/date/rdoc/DateTime.html#method-c-parse
```parse(str='-4712-01-01T00:00:00+00:00', comp=false, sg=ITALY)```

http://ruby-doc.org/stdlib-1.9.3/libdoc/date/rdoc/DateTime.html#method-c-parse
```parse(string='-4712-01-01T00:00:00+00:00'[, comp=true[, start=ITALY]])```

http://ruby-doc.org/stdlib-1.8.7/libdoc/date/rdoc/Date.html#method-c-parse
```parse(str='-4712-01-01', comp=false, sg=ITALY)```

http://ruby-doc.org/stdlib-1.9.3/libdoc/date/rdoc/Date.html#method-c-parse
```parse(string='-4712-01-01'[, comp=true[, start=ITALY]])```